### PR TITLE
Fixed devenv where VSC complained about input variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,3 @@ data/
 _autosave-*.kicad_pcb
 fp-info-cache
 \#auto_saved_files\#
-
-# Visual Studio Code.
-.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "gdbTarget"               : "localhost:61234",                           // "
             "overrideRestartCommands" : ["monitor reset"],                           // "
             "overrideLaunchCommands"  : ["load"],                                    // "
-            "executable"              : "./build/${input:TARGET}/${input:TARGET}.elf",
+            "executable"              : "./build/${config:TARGET}/${config:TARGET}.elf",
             "breakAfterReset"         : false,
         },
         {
@@ -22,7 +22,7 @@
             "gdbTarget"               : "localhost:61234",                           // "
             "overrideRestartCommands" : ["monitor reset"],                           // "
             "overrideLaunchCommands"  : ["load"],                                    // "
-            "executable"              : "./build/${input:TARGET}/${input:TARGET}.elf",
+            "executable"              : "./build/${config:TARGET}/${config:TARGET}.elf",
             "breakAfterReset"         : true,
         },
         {
@@ -34,7 +34,7 @@
             "gdbTarget"               : "localhost:61234",                           // "
             "overrideRestartCommands" : ["monitor reset"],                           // "
             "overrideLaunchCommands"  : ["load"],                                    // "
-            "executable"              : "./build/${input:TARGET}/${input:TARGET}.elf",
+            "executable"              : "./build/${config:TARGET}/${config:TARGET}.elf",
             "runToEntryPoint"         : "main",
         },
         {
@@ -45,7 +45,7 @@
             "preLaunchTask"           : "Make a GDB-server.", // "
             "gdbTarget"               : "localhost:61234",    // "
             "overrideRestartCommands" : ["monitor reset"],    // "
-            "executable"              : "./build/${input:TARGET}/${input:TARGET}.elf",
+            "executable"              : "./build/${config:TARGET}/${config:TARGET}.elf",
         },
     ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    // Set this to the name of the target you want to build, flash, and debug to.
+    // See `cli.py help build` for more information.
+    "TARGET": "",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,18 +1,11 @@
 {
     "version" : "2.0.0",
-    "inputs": [
-        {
-            "id"          : "TARGET",
-            "type"        : "promptString",
-            "description" : "The target to build, flash, and debug; an empty input will select the target automatically.",
-        }
-    ],
-    "tasks"   : [
+    "tasks" : [
         {
             "label"          : "Build the firmware.", // Use CTRL-SHIFT-B to build.
             "type"           : "shell",
             "command"        : "python",
-            "args"           : ["./cli.py", "build", "${input:TARGET}"],
+            "args"           : ["./cli.py", "build", "${config:TARGET}"],
             "problemMatcher" : [],
             "group"          : {
                 "kind"       : "build",
@@ -23,7 +16,7 @@
             "label"          : "Flash the firmware.",
             "type"           : "shell",
             "command"        : "python",
-            "args"           : ["./cli.py", "flash", "${input:TARGET}"],
+            "args"           : ["./cli.py", "flash", "${config:TARGET}"],
             "problemMatcher" : [],
         },
         { // @/`Deferred Task`.
@@ -34,7 +27,7 @@
             "label"          : "Make a GDB-server (deferred).",
             "type"           : "shell",
             "command"        : "python",
-            "args"           : ["./cli.py", "debug", "--just-gdbserver"],
+            "args"           : ["./cli.py", "debug", "${config:TARGET}", "--just-gdbserver"],
             "isBackground"   : true,
             "hide"           : true,
             "problemMatcher" : [ // @/`problemMatcher`.


### PR DESCRIPTION
There was a weird issue where the input variable `TARGET` defined in `tasks.json` won't transfer over to `launch.json` whenever we'd try to do a launch (just building was fine).

This would meant that the input variable would have to defined twice, once in `launch.json` and `tasks.json`. Obviously this ends up having the user the prompted twice for the target, and that's unacceptable.

There's an extension called [command variable](https://stackoverflow.com/questions/74766094/reference-a-variabled-in-tasks-json-that-was-defined-in-launch-json) which can "solve" this issue, it actually really didn't at all, because for some reason, the substitution of `TARGET` done first in the `launch.json` and then and only does the then prompt for `TARGET` appears. This ends up having things be out-of-sync. If you swap the place where the input variable `TARGET` is defined and remembered, then it'd work for launches, but now the prompt won't appear for pure `<CTRL-SHIFT-B>` builds.

So the solution now is to just have the target be defined in `settings.json`. No more prompts, so that's less convenient, but I think this will work for now.

Who in their right might thought JSON was a good format for something this complicated?