### PR TITLE
Instead of `python`, the name `python.exe` will be used instead on Windows.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,8 @@
         {
             "label"          : "Build the firmware.", // Use CTRL-SHIFT-B to build.
             "type"           : "shell",
-            "command"        : "python",
+            "command"        :               "python",
+            "windows"        : { "command" : "python.exe" },
             "args"           : ["./cli.py", "build", "${config:TARGET}"],
             "problemMatcher" : [],
             "group"          : {
@@ -15,7 +16,8 @@
         {
             "label"          : "Flash the firmware.",
             "type"           : "shell",
-            "command"        : "python",
+            "command"        :               "python",
+            "windows"        : { "command" : "python.exe" },
             "args"           : ["./cli.py", "flash", "${config:TARGET}"],
             "problemMatcher" : [],
         },
@@ -26,7 +28,8 @@
         {
             "label"          : "Make a GDB-server (deferred).",
             "type"           : "shell",
-            "command"        : "python",
+            "command"        :               "python",
+            "windows"        : { "command" : "python.exe" },
             "args"           : ["./cli.py", "debug", "${config:TARGET}", "--just-gdbserver"],
             "isBackground"   : true,
             "hide"           : true,


### PR DESCRIPTION
@Andrex2005 encountered a bug where building in Visual Studio Code would result in an error about `python` not being found despite Python being installed and in the PATH.

```
Program 'python' failed to run: No application is associated with the specified file for this operation
At line:1 char:1
+ python ./cli.py build
+ ~~~~~
    + CategoryInfo          : ResourceUnavailable: (:) [], ApplicationFailedException
    + FullyQualifiedErrorId : NativeCommandFailed
```

The fix to this seems to have the tasks execute `python.exe` as the command instead of just `python` on Windows.