### PR TITLE
Enforcing Python version.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6,9 +6,25 @@
 
 
 
+# Ensure Python version.
+
+import sys
+
+MAJOR = 3
+MINOR = 12
+if not (sys.version_info.major == MAJOR and sys.version_info.minor >= MINOR):
+    raise RuntimeError(
+        'Unsupported Python version: ' + repr(sys.version) + '; ' +
+        'please upgrade to at least ' + str(MAJOR) + '.' + str(MINOR) + '; '
+        'note that it is possible that you have multiple instances of Python installed; '
+        'in this case, please set your PATH accordingly or use a Python virtual environment.'
+    )
+
+
+
 # Built-in modules.
 
-import types, sys, shlex, pathlib, shutil, subprocess, time
+import types, shlex, pathlib, shutil, subprocess, time
 
 
 


### PR DESCRIPTION
@NadeemHuang encountered an issue with running `./cli.py` where it gave an obscure error message about f-strings. The problem being that Python 3.11 was used instead of 3.12 or higher, but the error message wasn't clear that this was the root issue. Thus, we'll enforce the Python version so that it'll be clearer to the next victim of Python versioning hell.