### PR TITLE
Deprecating `Meta.ifs`.

### DIFF
--- a/electrical/Shared.py
+++ b/electrical/Shared.py
@@ -1,4 +1,4 @@
-#meta STLINK_BAUD, TARGETS, MCUS :
+#meta STLINK_BAUD, TARGETS, MCUS, PER_TARGET, PER_MCU :
 
 from deps.pxd.utils import root
 import types
@@ -351,6 +351,36 @@ for target in TARGETS:
         -Xlinker --fatal-warnings
         -Xlinker --gc-sections
     '''
+
+
+
+################################################################################
+#
+# Some helpers for generating code that's specific to a particular target
+# or a particular MCU. This is better placed in <Helpers.py>, but a limitation
+# of the meta-preprocessor right now is that `TARGETS` and `MCUS` won't be
+# accessible there (TODO).
+#
+
+
+
+def PER_TARGET():
+
+    for target in TARGETS:
+
+        with Meta.enter(f'#if TARGET_NAME_IS_{target.name}'):
+
+            yield target
+
+
+
+def PER_MCU():
+
+    for mcu in MCUS:
+
+        with Meta.enter(f'#if TARGET_MCU_IS_{mcu}'):
+
+            yield mcu
 
 
 

--- a/electrical/i2c.c
+++ b/electrical/i2c.c
@@ -606,13 +606,10 @@ _I2C_update_entirely(enum I2CHandle handle)
 #include "i2c_interrupts.meta"
 /* #meta
 
-    @Meta.ifs(TARGETS, '#if')
-    def _(target):
-
-        yield f'TARGET_NAME_IS_{target.name}'
+    for target in PER_TARGET():
 
         if 'i2c_units' not in target.__dict__:
-            return
+            continue
 
         for unit in target.i2c_units:
             for suffix in ('EV', 'ER'):
@@ -655,10 +652,7 @@ _I2C_update_entirely(enum I2CHandle handle)
 
     # Some target-specific support definitions.
 
-    @Meta.ifs(TARGETS, '#if')
-    def _(target):
-
-        yield f'TARGET_NAME_IS_{target.name}'
+    for target in PER_TARGET():
 
         if 'i2c_units' not in target.__dict__ or not target.i2c_units:
 
@@ -667,7 +661,7 @@ _I2C_update_entirely(enum I2CHandle handle)
                 f'because no I2C unit have been assigned.'
             )
 
-            return
+            continue
 
 
 

--- a/electrical/system/Startup.S
+++ b/electrical/system/Startup.S
@@ -113,10 +113,7 @@ __INTERRUPT_Reset:
 
         # Make the IVT.
 
-        @Meta.ifs(TARGETS, '#if')
-        def _(target):
-
-            yield f'TARGET_NAME_IS_{target.name}'
+        for target in PER_TARGET():
 
             for interrupt_i, interrupt_name in enumerate(INTERRUPTS[target.mcu]):
 

--- a/electrical/system/defs.h
+++ b/electrical/system/defs.h
@@ -86,10 +86,7 @@ CMSIS_PUT(struct CMSISPutTuple tuple, u32 value)
 
     # Include the CMSIS device header for the STM32 microcontroller.
 
-    @Meta.ifs(MCUS, '#if')
-    def _(mcu):
-
-        yield f'TARGET_MCU_IS_{mcu}'
+    for mcu in PER_MCU():
 
         Meta.line(f'#include <{MCUS[mcu].cmsis_file_path.as_posix()}>')
 
@@ -153,10 +150,7 @@ CMSIS_PUT(struct CMSISPutTuple tuple, u32 value)
 
     # Handle aliasing of peripheral names.
 
-    @Meta.ifs(TARGETS, '#if')
-    def _(target):
-
-        yield f'TARGET_NAME_IS_{target.name}'
+    for target in PER_TARGET():
 
         for alias in target.aliases:
 
@@ -302,10 +296,7 @@ CMSIS_PUT(struct CMSISPutTuple tuple, u32 value)
 
 
 
-    @Meta.ifs(TARGETS, '#if')
-    def _(target):
-
-        yield f'TARGET_NAME_IS_{target.name}'
+    for target in PER_TARGET():
 
 
 
@@ -394,10 +385,7 @@ CMSIS_PUT(struct CMSISPutTuple tuple, u32 value)
 
     # Initialize the target's GPIOs, interrupts, clock-tree, etc.
 
-    @Meta.ifs(TARGETS, '#if')
-    def _(target):
-
-        yield f'TARGET_NAME_IS_{target.name}'
+    for target in PER_TARGET():
 
         with Meta.enter('''
             extern void
@@ -1124,10 +1112,7 @@ INTERRUPT_Default
 
     import re
 
-    @Meta.ifs(TARGETS, '#if')
-    def _(target):
-
-        yield f'TARGET_NAME_IS_{target.name}'
+    for target in PER_TARGET():
 
 
 
@@ -1177,7 +1162,7 @@ INTERRUPT_Default
         # Rest of the stuff is only when the target actually uses FreeRTOS.
 
         if not target.use_freertos:
-            return
+            continue
 
 
 
@@ -1223,13 +1208,12 @@ INTERRUPT_Default
 
     # The necessary include-directives to compile with FreeRTOS.
 
-    @Meta.ifs(MCUS, '#if')
-    def _(mcu):
+    for mcu in PER_MCU():
 
-        yield f'TARGET_MCU_IS_{mcu} && TARGET_USES_FREERTOS'
+        with Meta.enter('#if TARGET_USES_FREERTOS'):
 
-        for header in MCUS[mcu].freertos_source_files:
-            Meta.line(f'#include <{header}>')
+            for header in MCUS[mcu].freertos_source_files:
+                Meta.line(f'#include <{header}>')
 
 */
 


### PR DESCRIPTION
My meta-preprocessor had a helper routine for creating if-statements, but it was pretty contrived honestly.

All of the applications for `Meta.ifs` was for generating code specific to a target or particular MCU, so I just made helper routines just for that.