### PR TITLE
Patched broken parameterization of I2C.

### DIFF
--- a/electrical/DemoSPI.c
+++ b/electrical/DemoSPI.c
@@ -1,5 +1,6 @@
 #include "system.h"
 #include "uxart.c"
+#include "spi.c"
 
 
 
@@ -14,6 +15,15 @@ main(void)
 
     STPY_init();
     UXART_init(UXARTHandle_stlink);
+
+
+
+    ////////////////////////////////////////////////////////////////////////////////
+    //
+    // Initialize the SPI driver for each peripheral used by the target.
+    //
+
+    SPI_reinit(SPIHandle_primary);
 
 
 

--- a/electrical/Shared.py
+++ b/electrical/Shared.py
@@ -211,7 +211,7 @@ TARGETS = (
             'APB2_CK'      : 250_000_000,
             'APB3_CK'      : 250_000_000,
             'USART2_BAUD'  : STLINK_BAUD,
-            'I2C1_BAUD'    : 100_000,
+            'I2C1_BAUD'    : 1_000,
         },
 
     ),

--- a/electrical/Shared.py
+++ b/electrical/Shared.py
@@ -296,11 +296,15 @@ TARGETS = (
 
         interrupts = (
             ('USART2', 0),
+            ('SPI1'  , 1),
         ),
 
         drivers = {
             'UXART' : (
                 ('stlink', 'USART2'),
+            ),
+            'SPI' : (
+                ('primary', 'SPI1'),
             ),
         },
 

--- a/electrical/meta/STPY_init.meta
+++ b/electrical/meta/STPY_init.meta
@@ -1123,8 +1123,8 @@
 
 
 
-            #define STPY_I2C1_KERNEL_SOURCE 0b11
-            #define STPY_I2C1_PRESC 15
+            #define STPY_I2C1_KERNEL_SOURCE 0b00
+            #define STPY_I2C1_PRESC 4
             #define STPY_I2C1_SCLH 250
             #define STPY_I2C1_SCLL 250
 

--- a/electrical/meta/STPY_init.meta
+++ b/electrical/meta/STPY_init.meta
@@ -1123,8 +1123,8 @@
 
 
 
-            #define STPY_I2C1_KERNEL_SOURCE 0b00
-            #define STPY_I2C1_PRESC 4
+            #define STPY_I2C1_KERNEL_SOURCE 0b11
+            #define STPY_I2C1_PRESC 7
             #define STPY_I2C1_SCLH 250
             #define STPY_I2C1_SCLL 250
 

--- a/electrical/meta/STPY_init.meta
+++ b/electrical/meta/STPY_init.meta
@@ -1512,11 +1512,13 @@
         enum NVICInterrupt : u32
         {
             NVICInterrupt_USART2 = USART2_IRQn,
+            NVICInterrupt_SPI1   = SPI1_IRQn,
         };
-        static constexpr u32 NVICInterrupt_COUNT = 1;
+        static constexpr u32 NVICInterrupt_COUNT = 2;
         extern void INTERRUPT_BusFault(void);
         extern void INTERRUPT_Default(void);
         extern void INTERRUPT_Reset(void);
+        extern void INTERRUPT_SPI1(void);
         extern void INTERRUPT_USART2(void);
         extern void INTERRUPT_UsageFault(void);
         void (* const INTERRUPT_VECTOR_TABLE[])(void) __attribute__((used, section(".INTERRUPT_VECTOR_TABLE"))) =
@@ -1592,7 +1594,7 @@
                 INTERRUPT_Default            , // [ 52] I2C1_ER
                 INTERRUPT_Default            , // [ 53] I2C2_EV
                 INTERRUPT_Default            , // [ 54] I2C2_ER
-                INTERRUPT_Default            , // [ 55] SPI1
+                INTERRUPT_SPI1               , // [ 55] SPI1
                 INTERRUPT_Default            , // [ 56] SPI2
                 INTERRUPT_Default            , // [ 57] SPI3
                 INTERRUPT_Default            , // [ 58] USART1
@@ -1674,6 +1676,7 @@
         #define INTERRUPT_BusFault extern void INTERRUPT_BusFault(void)
         #define INTERRUPT_Default extern void INTERRUPT_Default(void)
         #define INTERRUPT_Reset extern void INTERRUPT_Reset(void)
+        #define INTERRUPT_SPI1 extern void INTERRUPT_SPI1(void)
         #define INTERRUPT_USART2 extern void INTERRUPT_USART2(void)
         #define INTERRUPT_UsageFault extern void INTERRUPT_UsageFault(void)
         extern void
@@ -1725,6 +1728,8 @@
 
             static_assert(0 <= 0 && 0 < (1 << __NVIC_PRIO_BITS));
             NVIC->IPR[NVICInterrupt_USART2] = 0 << __NVIC_PRIO_BITS;
+            static_assert(0 <= 1 && 1 < (1 << __NVIC_PRIO_BITS));
+            NVIC->IPR[NVICInterrupt_SPI1] = 1 << __NVIC_PRIO_BITS;
             CMSIS_SET
             (
                 SCB        , SHCSR,

--- a/electrical/meta/spi_driver_support.meta
+++ b/electrical/meta/spi_driver_support.meta
@@ -1,0 +1,56 @@
+#if TARGET_NAME_IS_SandboxNucleoH7S3L8
+    #error Target "SandboxNucleoH7S3L8" cannot use the SPI driver without first specifying the peripheral instances to have handles for.
+#endif
+#if TARGET_NAME_IS_SandboxNucleoH533RE
+    #error Target "SandboxNucleoH533RE" cannot use the SPI driver without first specifying the peripheral instances to have handles for.
+#endif
+#if TARGET_NAME_IS_DemoI2C
+    #error Target "DemoI2C" cannot use the SPI driver without first specifying the peripheral instances to have handles for.
+#endif
+#if TARGET_NAME_IS_DemoTimer
+    #error Target "DemoTimer" cannot use the SPI driver without first specifying the peripheral instances to have handles for.
+#endif
+#if TARGET_NAME_IS_DemoSPI
+    enum SPIHandle : u32
+    {
+        SPIHandle_primary,
+    };
+    static constexpr u32 SPIHandle_COUNT = 1;
+    #define SPIx_ SPI_
+    static const struct { typeof(SPI1) SPIx; } SPI_TABLE[] =
+        {
+            [SPIHandle_primary] = { .SPIx = SPI1 },
+        };
+#endif
+#undef _EXPAND_HANDLE
+#define _EXPAND_HANDLE\
+    \
+    if (!(0 <= handle && handle < SPIHandle_COUNT))\
+    {\
+        panic;\
+    }\
+    \
+    struct SPIDriver* const driver = &_SPI_drivers[handle];\
+    \
+    auto const SPIx = SPI_TABLE[handle].SPIx;\
+
+
+#if TARGET_NAME_IS_SandboxNucleoH7S3L8
+#endif
+#if TARGET_NAME_IS_SandboxNucleoH533RE
+#endif
+#if TARGET_NAME_IS_DemoI2C
+#endif
+#if TARGET_NAME_IS_DemoTimer
+#endif
+#if TARGET_NAME_IS_DemoSPI
+
+    static void
+    _SPI_update_entirely(enum SPIHandle handle);
+
+    INTERRUPT_SPI1
+    {
+        _SPI_update_entirely(SPIHandle_primary);
+    }
+
+#endif

--- a/electrical/meta/spi_driver_support.meta
+++ b/electrical/meta/spi_driver_support.meta
@@ -17,9 +17,9 @@
     };
     static constexpr u32 SPIHandle_COUNT = 1;
     #define SPIx_ SPI_
-    static const struct { typeof(SPI1) SPIx; } SPI_TABLE[] =
+    static const struct { typeof(SPI1) SPIx; typeof(NVICInterrupt_SPI1) NVICInterrupt_SPIx; typeof((struct CMSISTuple) { &RCC->APB2RSTR, RCC_APB2RSTR_SPI1RST_Pos, RCC_APB2RSTR_SPI1RST_Msk }) SPIx_RESET; typeof((struct CMSISTuple) { &RCC->APB2ENR, RCC_APB2ENR_SPI1EN_Pos, RCC_APB2ENR_SPI1EN_Msk }) SPIx_ENABLE; } SPI_TABLE[] =
         {
-            [SPIHandle_primary] = { .SPIx = SPI1 },
+            [SPIHandle_primary] = { .SPIx = SPI1, .NVICInterrupt_SPIx = NVICInterrupt_SPI1, .SPIx_RESET = (struct CMSISTuple) { &RCC->APB2RSTR, RCC_APB2RSTR_SPI1RST_Pos, RCC_APB2RSTR_SPI1RST_Msk }, .SPIx_ENABLE = (struct CMSISTuple) { &RCC->APB2ENR, RCC_APB2ENR_SPI1EN_Pos, RCC_APB2ENR_SPI1EN_Msk } },
         };
 #endif
 #undef _EXPAND_HANDLE
@@ -33,6 +33,9 @@
     struct SPIDriver* const driver = &_SPI_drivers[handle];\
     \
     auto const SPIx = SPI_TABLE[handle].SPIx;\
+    auto const NVICInterrupt_SPIx = SPI_TABLE[handle].NVICInterrupt_SPIx;\
+    auto const SPIx_RESET = SPI_TABLE[handle].SPIx_RESET;\
+    auto const SPIx_ENABLE = SPI_TABLE[handle].SPIx_ENABLE;\
 
 
 #if TARGET_NAME_IS_SandboxNucleoH7S3L8

--- a/electrical/spi.c
+++ b/electrical/spi.c
@@ -10,8 +10,11 @@
         cmsis_name  = 'SPI',
         common_name = 'SPIx',
         identifiers = (
+            'NVICInterrupt_{}',
         ),
         cmsis_tuple_tags = (
+            '{}_RESET',
+            '{}_ENABLE',
         ),
     )
 
@@ -62,6 +65,37 @@ SPI_reinit(enum SPIHandle handle)
 {
 
     _EXPAND_HANDLE
+
+
+
+    // Reset-cycle the peripheral.
+
+    CMSIS_PUT(SPIx_RESET, true );
+    CMSIS_PUT(SPIx_RESET, false);
+
+    *driver = (struct SPIDriver) {0};
+
+
+
+    // Enable the interrupts.
+
+    NVIC_ENABLE(SPIx);
+
+
+
+    // Set the kernel clock source for the peripheral.
+
+    // TODO.
+
+
+
+    // Enable the peripheral.
+
+    CMSIS_PUT(SPIx_ENABLE, true);
+
+
+
+    // Configure the peripheral.
 
     sorry
 

--- a/electrical/spi.c
+++ b/electrical/spi.c
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+#include "spi_driver_support.meta"
+/* #meta
+
+    IMPLEMENT_DRIVER_ALIASES(
+        driver_name = 'SPI',
+        cmsis_name  = 'SPI',
+        common_name = 'SPIx',
+        identifiers = (
+        ),
+        cmsis_tuple_tags = (
+        ),
+    )
+
+    for target in PER_TARGET():
+
+        for handle, instance in target.drivers.get('SPI', ()):
+
+            Meta.line(f'''
+
+                static void
+                _SPI_update_entirely(enum SPIHandle handle);
+
+                INTERRUPT_{instance}
+                {{
+                    _SPI_update_entirely(SPIHandle_{handle});
+                }}
+
+            ''')
+
+*/
+
+
+
+enum SPIDriverState : u32
+{
+    SPIDriverState_standby,
+};
+
+
+
+struct SPIDriver
+{
+    volatile enum SPIDriverState state;
+};
+
+
+
+static struct SPIDriver _SPI_drivers[SPIHandle_COUNT] = {0};
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+static void
+SPI_reinit(enum SPIHandle handle)
+{
+
+    _EXPAND_HANDLE
+
+    sorry
+
+}
+
+
+
+static void
+_SPI_update_entirely(enum SPIHandle handle)
+{
+    sorry
+}


### PR DESCRIPTION
While I was working on SPI driver, I realized that the parameterization of I2C was broken where the desired baud was calculated incorrectly. This has now been fixed.