### PR TITLE
Fixed user-input button logic activation level for `SandboxNucleo` targets.

### DIFF
--- a/electrical/SandboxNucleoBoard.c
+++ b/electrical/SandboxNucleoBoard.c
@@ -21,15 +21,25 @@ main(void)
         for (i32 iteration = 0;; iteration += 1)
         {
 
+            // @/`Nucleo Buttons`.
+
+            b32 button_active = GPIO_READ(button);
+
+            #if TARGET_NAME_IS_SandboxNucleoH7S3L8
+                button_active = !button_active;
+            #endif
+
+
+
             // Blink the LED.
 
-            if (GPIO_READ(button)) // @/`Nucleo Buttons`.
+            if (button_active)
             {
-                spinlock_nop(100'000'000);
+                spinlock_nop(50'000'000);
             }
             else
             {
-                spinlock_nop(50'000'000);
+                spinlock_nop(100'000'000);
             }
 
             GPIO_TOGGLE(led_green);
@@ -86,7 +96,11 @@ FREERTOS_TASK(button_observer, 1024, 0)
 
         // @/`Nucleo Buttons`.
 
-        b32 current_button_pressed = !GPIO_READ(button);
+        b32 current_button_pressed = GPIO_READ(button);
+
+        #if TARGET_NAME_IS_SandboxNucleoH7S3L8
+            current_button_pressed = !current_button_pressed;
+        #endif
 
 
 
@@ -480,6 +494,8 @@ FREERTOS_TASK(captain_allears, 1024, 0)
 // You can write your SPI drivers and what not, and then later we worry about
 // how to make sure we can use it in a concurrent-safe way.
 
+
+
 // @/`Nucleo Buttons`:
 //
 // There's two buttons on Nucleo boards: one for reset and one for the
@@ -488,7 +504,6 @@ FREERTOS_TASK(captain_allears, 1024, 0)
 // the user manual or just by inspecting the PCB file of the Nucleo board.
 // The way we define GPIOs is in the file <Shared.py> with the option `gpios`.
 //
-// Note that the way the button is implemented on the Nucleo boards is that
-// pressing it will tie the GPIO to ground. Thus, if we read a high value
-// on the GPIO, then the button is unpressed; if it's zero, then the button
-// is pressed.
+// Note that the way the button is implemented on the Nucleo boards varies;
+// sometimes the button connect the input GPIO to VDD or GND, and sometimes
+// there's a pull resistor and sometimes not.

--- a/electrical/Shared.py
+++ b/electrical/Shared.py
@@ -130,7 +130,7 @@ TARGETS = (
             ('stlink_rx' , 'A3' , 'ALTERNATE' , { 'altfunc' : 'USART2_RX' }),
             ('swdio'     , 'A13', None        , {                         }),
             ('swclk'     , 'A14', None        , {                         }),
-            ('button'    , 'C13', 'INPUT'     , { 'pull'    : 'UP'        }),
+            ('button'    , 'C13', 'INPUT'     , { 'pull'    : None        }),
         ),
 
         interrupts = (
@@ -179,7 +179,7 @@ TARGETS = (
             ('stlink_rx' , 'A3' , 'ALTERNATE' , { 'altfunc' : 'USART2_RX'                                    }),
             ('swdio'     , 'A13', None        , {                                                            }),
             ('swclk'     , 'A14', None        , {                                                            }),
-            ('button'    , 'C13', 'INPUT'     , { 'pull'    : 'UP'                                           }),
+            ('button'    , 'C13', 'INPUT'     , { 'pull'    : None                                           }),
             ('i2c1_scl'  , 'B6' , 'ALTERNATE' , { 'altfunc' : 'I2C1_SCL', 'open_drain' : True, 'pull' : 'UP' }),
             ('i2c1_sda'  , 'B7' , 'ALTERNATE' , { 'altfunc' : 'I2C1_SDA', 'open_drain' : True, 'pull' : 'UP' }),
         ),
@@ -236,7 +236,7 @@ TARGETS = (
             ('stlink_rx' , 'A3' , 'ALTERNATE' , { 'altfunc' : 'USART2_RX' }),
             ('swdio'     , 'A13', None        , {                         }),
             ('swclk'     , 'A14', None        , {                         }),
-            ('button'    , 'C13', 'INPUT'     , { 'pull'    : 'UP'        }),
+            ('button'    , 'C13', 'INPUT'     , { 'pull'    : None        }),
             ('OC1'       , 'A8' , 'ALTERNATE' , { 'altfunc' : 'TIM1_CH1'  }),
             ('OC1N'      , 'A7' , 'ALTERNATE' , { 'altfunc' : 'TIM1_CH1N' }),
         ),
@@ -290,7 +290,7 @@ TARGETS = (
             ('stlink_rx' , 'A3' , 'ALTERNATE' , { 'altfunc' : 'USART2_RX' }),
             ('swdio'     , 'A13', None        , {                         }),
             ('swclk'     , 'A14', None        , {                         }),
-            ('button'    , 'C13', 'INPUT'     , { 'pull'    : 'UP'        }),
+            ('button'    , 'C13', 'INPUT'     , { 'pull'    : None        }),
         ),
 
 

--- a/electrical/meta/STPY_init.meta
+++ b/electrical/meta/STPY_init.meta
@@ -608,7 +608,6 @@
                 GPIOCEN, true   ,
             );
             CMSIS_SET(GPIOA, ODR, OD5, false);
-            CMSIS_SET(GPIOC, PUPDR, PUPD13, 0b01);
             CMSIS_WRITE
             (
                 GPIO_AFRL, GPIOA->AFR[0],
@@ -971,7 +970,6 @@
                 PUPD6, 0b01 ,
                 PUPD7, 0b01 ,
             );
-            CMSIS_SET(GPIOC, PUPDR, PUPD13, 0b01);
             CMSIS_WRITE
             (
                 GPIO_AFRL, GPIOA->AFR[0],
@@ -1345,7 +1343,6 @@
                 GPIOCEN, true   ,
             );
             CMSIS_SET(GPIOA, ODR, OD5, false);
-            CMSIS_SET(GPIOC, PUPDR, PUPD13, 0b01);
             CMSIS_WRITE
             (
                 GPIO_AFRL, GPIOA->AFR[0],
@@ -1704,7 +1701,6 @@
                 GPIOCEN, true   ,
             );
             CMSIS_SET(GPIOA, ODR, OD5, false);
-            CMSIS_SET(GPIOC, PUPDR, PUPD13, 0b01);
             CMSIS_WRITE
             (
                 GPIO_AFRL, GPIOA->AFR[0],


### PR DESCRIPTION
The Nucleo-H533RE has the user-input button active-high with a pull-down resistor already on the board, which is different from the Nucleo-H7S3L8 where there was no pull resistor and the button was active-low. This has now been taken into consideration.