### PR TITLE
Ported Maggie's schematic for timer event conversion.

### DIFF
--- a/pcb/MainPowerDistributionSystem.kicad_pro
+++ b/pcb/MainPowerDistributionSystem.kicad_pro
@@ -652,12 +652,40 @@
       "Root"
     ],
     [
+      "261c9762-dbc6-4b8c-91f7-76f368e53a64",
+      "Timer Event Logic Conversion - TE-1"
+    ],
+    [
+      "5794667a-7b17-4495-a615-6983a1fee026",
+      "Timer Event Logic Conversion - TE-2"
+    ],
+    [
+      "3f92f74e-3cca-4282-aab2-357fe1c1118f",
+      "Timer Event Logic Conversion - TE-3"
+    ],
+    [
       "0f780159-799d-4240-a0dc-e97323accb24",
       "Burnwire Regulator - 1"
     ],
     [
       "7ea803d7-eeec-4516-a8ae-4c33da2eb13f",
       "Burnwire Regulator - 2"
+    ],
+    [
+      "808cc913-2635-4e01-9a87-a42fd91b330a",
+      "Timer Event Logic Conversion - TE-RA"
+    ],
+    [
+      "7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8",
+      "Timer Event Logic Conversion - TE-RB"
+    ],
+    [
+      "41b9944a-f63d-4ce0-843f-6c1f8b109fe2",
+      "Timer Event Logic Conversion - GSE-1"
+    ],
+    [
+      "5cd708ab-f243-4c3d-b9a6-6ef81c5046b4",
+      "Timer Event Logic Conversion - GSE-2"
     ]
   ],
   "text_variables": {}

--- a/pcb/MainPowerDistributionSystem.kicad_sch
+++ b/pcb/MainPowerDistributionSystem.kicad_sch
@@ -1140,478 +1140,6 @@
 			)
 			(embedded_fonts no)
 		)
-		(symbol "Device:C"
-			(pin_numbers
-				(hide yes)
-			)
-			(pin_names
-				(offset 0.254)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "C"
-				(at 0.635 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Value" "C"
-				(at 0.635 -2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(justify left)
-				)
-			)
-			(property "Footprint" ""
-				(at 0.9652 -3.81 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Unpolarized capacitor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "cap capacitor"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "C_*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "C_0_1"
-				(polyline
-					(pts
-						(xy -2.032 0.762) (xy 2.032 0.762)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -2.032 -0.762) (xy 2.032 -0.762)
-					)
-					(stroke
-						(width 0.508)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "C_1_1"
-				(pin passive line
-					(at 0 3.81 270)
-					(length 2.794)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 0 -3.81 90)
-					(length 2.794)
-					(name "~"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
-		(symbol "Device:D_Zener"
-			(pin_numbers
-				(hide yes)
-			)
-			(pin_names
-				(offset 1.016)
-				(hide yes)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "D"
-				(at 0 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "D_Zener"
-				(at 0 -2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Zener diode"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "diode"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "D_Zener_0_1"
-				(polyline
-					(pts
-						(xy -1.27 -1.27) (xy -1.27 1.27) (xy -0.762 1.27)
-					)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 1.27 0) (xy -1.27 0)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
-					)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "D_Zener_1_1"
-				(pin passive line
-					(at -3.81 0 0)
-					(length 2.54)
-					(name "K"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 3.81 0 180)
-					(length 2.54)
-					(name "A"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
-		(symbol "Device:LED"
-			(pin_numbers
-				(hide yes)
-			)
-			(pin_names
-				(offset 1.016)
-				(hide yes)
-			)
-			(exclude_from_sim no)
-			(in_bom yes)
-			(on_board yes)
-			(property "Reference" "D"
-				(at 0 2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Value" "LED"
-				(at 0 -2.54 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-				)
-			)
-			(property "Footprint" ""
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Datasheet" "~"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Description" "Light emitting diode"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "Sim.Pins" "1=K 2=A"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_keywords" "LED diode"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
-				(at 0 0 0)
-				(effects
-					(font
-						(size 1.27 1.27)
-					)
-					(hide yes)
-				)
-			)
-			(symbol "LED_0_1"
-				(polyline
-					(pts
-						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.27 0) (xy 1.27 0)
-					)
-					(stroke
-						(width 0)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy -1.27 -1.27) (xy -1.27 1.27)
-					)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-				(polyline
-					(pts
-						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
-					)
-					(stroke
-						(width 0.254)
-						(type default)
-					)
-					(fill
-						(type none)
-					)
-				)
-			)
-			(symbol "LED_1_1"
-				(pin passive line
-					(at -3.81 0 0)
-					(length 2.54)
-					(name "K"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "1"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-				(pin passive line
-					(at 3.81 0 180)
-					(length 2.54)
-					(name "A"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-					(number "2"
-						(effects
-							(font
-								(size 1.27 1.27)
-							)
-						)
-					)
-				)
-			)
-			(embedded_fonts no)
-		)
 		(symbol "Device:R"
 			(pin_numbers
 				(hide yes)
@@ -4344,19 +3872,6 @@
 		)
 		(uuid "5af5498f-5fb1-4229-86e9-2a570c9cde25")
 	)
-	(text "Expected to draw 6.3mA - 9mA at 24V - 32V.\nPower disipated: 120mW - 241mW.\n\nResistor that allows for the highest current to\nthe zener without exceding its power rating.\n\nNote: Testing shows that zener can run at \nlower currents than specified on data sheet."
-		(exclude_from_sim no)
-		(at 213.36 320.548 0)
-		(effects
-			(font
-				(size 1.27 1.27)
-				(thickness 0.1588)
-				(color 255 0 0 1)
-			)
-			(justify right)
-		)
-		(uuid "5e8d7462-12f7-41b4-99c7-997046a0f370")
-	)
 	(text "Logic Conversion."
 		(exclude_from_sim no)
 		(at 130.81 262.382 0)
@@ -4399,12 +3914,6 @@
 		(uuid "267bad22-b485-42cd-b371-6d0962cb96d8")
 	)
 	(junction
-		(at 217.17 326.39)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "815cbfa7-a19d-4e3b-b7d8-20bcc64d52d9")
-	)
-	(junction
 		(at 260.35 102.87)
 		(diameter 0)
 		(color 0 0 0 0)
@@ -4415,12 +3924,6 @@
 		(diameter 0)
 		(color 0 0 0 0)
 		(uuid "d7f03104-8a43-4860-9c41-5734d440a03d")
-	)
-	(junction
-		(at 237.49 326.39)
-		(diameter 0)
-		(color 0 0 0 0)
-		(uuid "e9623cf2-9835-4257-8a16-ab45ecd7779a")
 	)
 	(no_connect
 		(at 424.18 212.09)
@@ -4732,26 +4235,6 @@
 	)
 	(wire
 		(pts
-			(xy 217.17 337.82) (xy 217.17 341.63)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "17eb36bd-76ac-4622-baac-db919761a17e")
-	)
-	(wire
-		(pts
-			(xy 217.17 302.26) (xy 217.17 297.18)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "1b31662b-32c2-422a-a03c-11fe3d0b5cd4")
-	)
-	(wire
-		(pts
 			(xy 198.12 86.36) (xy 190.5 86.36)
 		)
 		(stroke
@@ -4782,16 +4265,6 @@
 	)
 	(wire
 		(pts
-			(xy 237.49 326.39) (xy 237.49 330.2)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "4d7f9bd9-b85d-452d-8aef-ac5dd9bf377a")
-	)
-	(wire
-		(pts
 			(xy 260.35 81.28) (xy 260.35 102.87)
 		)
 		(stroke
@@ -4799,26 +4272,6 @@
 			(type default)
 		)
 		(uuid "4fb46aad-46da-40ab-82d4-cfc14f6a571a")
-	)
-	(wire
-		(pts
-			(xy 217.17 309.88) (xy 217.17 314.96)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "552fd5c1-5861-475c-9297-a2ad9476104a")
-	)
-	(wire
-		(pts
-			(xy 217.17 326.39) (xy 217.17 330.2)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "68ad0987-906c-4784-86c7-667e4a3bad40")
 	)
 	(wire
 		(pts
@@ -4862,26 +4315,6 @@
 	)
 	(wire
 		(pts
-			(xy 237.49 337.82) (xy 237.49 341.63)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b00991f8-fef5-4485-907a-c5349e4acffb")
-	)
-	(wire
-		(pts
-			(xy 237.49 326.39) (xy 248.92 326.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "b88b5802-7570-438c-a437-f9aa318f1e2c")
-	)
-	(wire
-		(pts
 			(xy 181.61 86.36) (xy 185.42 86.36)
 		)
 		(stroke
@@ -4889,16 +4322,6 @@
 			(type default)
 		)
 		(uuid "bd24c19b-7dcf-4944-9550-b1473025687c")
-	)
-	(wire
-		(pts
-			(xy 217.17 326.39) (xy 237.49 326.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "c036689c-3109-463a-a320-c107d751e5c9")
 	)
 	(wire
 		(pts
@@ -4949,16 +4372,6 @@
 			(type default)
 		)
 		(uuid "f0f0efb5-322f-42e6-b7e1-e097a867132f")
-	)
-	(wire
-		(pts
-			(xy 217.17 322.58) (xy 217.17 326.39)
-		)
-		(stroke
-			(width 0)
-			(type default)
-		)
-		(uuid "f2f223d4-ffc0-49f7-9e01-afc29dcda59a")
 	)
 	(global_label "MOTOR_DIR_X"
 		(shape bidirectional)
@@ -5048,6 +4461,28 @@
 			)
 		)
 	)
+	(global_label "LOGIC_TIMER_EVENT_B"
+		(shape bidirectional)
+		(at 275.59 354.33 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "1de71317-031b-4abc-90de-5b40ccfe58de")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 300.4902 354.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
 	(global_label "MOTOR_DRIVER_B1_X"
 		(shape bidirectional)
 		(at 396.24 234.95 0)
@@ -5061,6 +4496,28 @@
 		(uuid "2ff8dd8b-fe45-432d-a7fd-77ea54d064aa")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
 			(at 419.9307 234.95 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "LOGIC_TIMER_EVENT_2"
+		(shape bidirectional)
+		(at 275.59 303.53 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "34994aa1-f128-4777-96ad-1c0613f3dea1")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 300.4297 303.53 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5290,6 +4747,28 @@
 			)
 		)
 	)
+	(global_label "LOGIC_TIMER_EVENT_3"
+		(shape bidirectional)
+		(at 275.59 321.31 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "6b53585e-dc28-4360-848a-77ea709809e7")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 300.4297 321.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
 	(global_label "MOTOR_DIR_Z"
 		(shape bidirectional)
 		(at 355.6 194.31 180)
@@ -5378,6 +4857,28 @@
 			)
 		)
 	)
+	(global_label "LOGIC_TIMER_EVENT_1"
+		(shape bidirectional)
+		(at 275.59 284.48 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "794dfe06-9bc9-4bba-a05d-21077d1ae50a")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 300.4297 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
 	(global_label "MOTOR_DRIVER_B1_Z"
 		(shape bidirectional)
 		(at 396.24 245.11 0)
@@ -5391,6 +4892,28 @@
 		(uuid "861eb196-53b3-4896-9485-dd541a1156ce")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
 			(at 419.9307 245.11 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
+	(global_label "LOGIC_GSE_1"
+		(shape bidirectional)
+		(at 190.5 284.48 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "9aa518f1-6e20-4d23-b339-93274698171e")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 206.8731 284.48 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5466,9 +4989,9 @@
 			)
 		)
 	)
-	(global_label "LOGIC_TIMER_EVENT_1"
+	(global_label "LOGIC_TIMER_EVENT_A"
 		(shape bidirectional)
-		(at 248.92 326.39 0)
+		(at 275.59 337.82 0)
 		(fields_autoplaced yes)
 		(effects
 			(font
@@ -5476,9 +4999,9 @@
 			)
 			(justify left)
 		)
-		(uuid "e391ec91-e50d-477d-83bc-1698d26e88da")
+		(uuid "e4347e01-b4bf-4d96-93b1-eb455a47fd33")
 		(property "Intersheetrefs" "${INTERSHEET_REFS}"
-			(at 273.7597 326.39 0)
+			(at 300.3088 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -5510,6 +5033,28 @@
 			)
 		)
 	)
+	(global_label "LOGIC_GSE_2"
+		(shape bidirectional)
+		(at 190.5 303.53 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "e9090035-80af-4cde-b1b5-794b6d6e2d2d")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 206.8731 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
 	(global_label "MOTOR_UART_RX"
 		(shape bidirectional)
 		(at 355.6 102.87 180)
@@ -5529,6 +5074,73 @@
 				)
 				(justify right)
 				(hide yes)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
+		(at 151.13 284.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "02af7699-0ed3-4b1e-9d27-a9657686c768")
+		(property "Reference" "#PWR062"
+			(at 154.94 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+GSE-1"
+			(at 147.32 284.4799 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 151.13 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 151.13 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 151.13 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f3fca5f6-63be-4b93-964a-4dcd2024db73")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(reference "#PWR062")
+					(unit 1)
+				)
 			)
 		)
 	)
@@ -5593,76 +5205,6 @@
 			(project "MainPowerDistributionSystem"
 				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
 					(reference "#PWR039")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:C")
-		(at 237.49 334.01 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "0486685a-1100-4a71-9d86-d3952ae92015")
-		(property "Reference" "C1"
-			(at 241.3 332.7399 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "1u"
-			(at 241.3 335.2799 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric_Pad1.33x1.80mm_HandSolder"
-			(at 238.4552 337.82 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 237.49 334.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Unpolarized capacitor"
-			(at 237.49 334.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "d192d4a4-3044-4fd5-87f3-ee7edbafd346")
-		)
-		(pin "2"
-			(uuid "c976d881-feed-4bd4-8a25-d805595521c3")
-		)
-		(instances
-			(project "MainPowerDistributionSystem"
-				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "C1")
 					(unit 1)
 				)
 			)
@@ -6070,17 +5612,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 217.17 341.63 0)
+		(lib_id "power:+3.3V")
+		(at 236.22 354.33 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "1ce204b0-632a-4b87-a634-19f2f6e12561")
-		(property "Reference" "#PWR088"
-			(at 217.17 347.98 0)
+		(uuid "1d648cc5-3bbe-475b-8aca-fce2fc206364")
+		(property "Reference" "#PWR059"
+			(at 240.03 354.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6088,17 +5630,17 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "GND"
-			(at 217.17 346.71 0)
+		(property "Value" "+TE-RB"
+			(at 232.41 354.3299 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
+				(justify left)
 			)
 		)
 		(property "Footprint" ""
-			(at 217.17 341.63 0)
+			(at 236.22 354.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6107,7 +5649,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 217.17 341.63 0)
+			(at 236.22 354.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6115,8 +5657,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 217.17 341.63 0)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 236.22 354.33 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -6125,12 +5667,12 @@
 			)
 		)
 		(pin "1"
-			(uuid "f366beef-6cf6-4c56-8a2d-4aaa90064eab")
+			(uuid "5eb136b3-7a89-418f-9333-91f96a50179c")
 		)
 		(instances
 			(project "MainPowerDistributionSystem"
 				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "#PWR088")
+					(reference "#PWR059")
 					(unit 1)
 				)
 			)
@@ -6342,6 +5884,73 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+3.3V")
+		(at 236.22 303.53 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "3beff736-c4fa-43f6-a595-a71cad9c89c6")
+		(property "Reference" "#PWR013"
+			(at 240.03 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+TE-2"
+			(at 232.41 303.5299 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 236.22 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 236.22 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 236.22 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "60d21b44-ca64-45cb-bbe9-7d62b92f1fae")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(reference "#PWR013")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
 		(at 355.6 120.65 270)
 		(unit 1)
@@ -6534,85 +6143,6 @@
 			(project "MainPowerDistributionSystem"
 				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
 					(reference "#PWR041")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:LED")
-		(at 217.17 306.07 90)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "47ca0805-3ef8-46f9-9226-a167b5d979c8")
-		(property "Reference" "D4"
-			(at 220.98 306.3874 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Value" "RED"
-			(at 220.98 308.9274 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify right)
-			)
-		)
-		(property "Footprint" "LED_SMD:LED_1206_3216Metric_Pad1.42x1.75mm_HandSolder"
-			(at 217.17 306.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 217.17 306.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Light emitting diode"
-			(at 217.17 306.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Sim.Pins" "1=K 2=A"
-			(at 217.17 306.07 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "b7f17907-6906-459d-a8a1-2ffc0116bec1")
-		)
-		(pin "2"
-			(uuid "a68837f9-a459-4cd0-9cbd-651b00a4e943")
-		)
-		(instances
-			(project "MainPowerDistributionSystem"
-				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "D4")
 					(unit 1)
 				)
 			)
@@ -7786,76 +7316,6 @@
 		)
 	)
 	(symbol
-		(lib_id "Device:R")
-		(at 217.17 318.77 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "8404fa5e-050c-4960-a21c-653c303e3e11")
-		(property "Reference" "R2"
-			(at 219.71 317.4999 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "3k"
-			(at 219.71 320.0399 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Resistor_SMD:R_1206_3216Metric_Pad1.30x1.75mm_HandSolder"
-			(at 215.392 318.77 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 217.17 318.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Resistor"
-			(at 217.17 318.77 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "2"
-			(uuid "ec951712-447f-4018-a259-faf87a64d19f")
-		)
-		(pin "1"
-			(uuid "8f996855-7144-4e3c-8061-105535a26c9b")
-		)
-		(instances
-			(project "MainPowerDistributionSystem"
-				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "R2")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
 		(lib_id "power:+3.3V")
 		(at 396.24 250.19 270)
 		(mirror x)
@@ -7923,17 +7383,17 @@
 		)
 	)
 	(symbol
-		(lib_id "power:GND")
-		(at 237.49 341.63 0)
+		(lib_id "power:+3.3V")
+		(at 236.22 337.82 90)
 		(unit 1)
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
 		(dnp no)
 		(fields_autoplaced yes)
-		(uuid "8a84e190-8619-43e2-9cbf-5aec959f50e3")
-		(property "Reference" "#PWR089"
-			(at 237.49 347.98 0)
+		(uuid "867e62b7-6a51-4cd5-9437-7242b2365bd6")
+		(property "Reference" "#PWR056"
+			(at 240.03 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7941,17 +7401,17 @@
 				(hide yes)
 			)
 		)
-		(property "Value" "GND"
-			(at 237.49 346.71 0)
+		(property "Value" "+TE-RA"
+			(at 232.41 337.8199 90)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
+				(justify left)
 			)
 		)
 		(property "Footprint" ""
-			(at 237.49 341.63 0)
+			(at 236.22 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7960,7 +7420,7 @@
 			)
 		)
 		(property "Datasheet" ""
-			(at 237.49 341.63 0)
+			(at 236.22 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7968,8 +7428,8 @@
 				(hide yes)
 			)
 		)
-		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
-			(at 237.49 341.63 0)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 236.22 337.82 0)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -7978,12 +7438,12 @@
 			)
 		)
 		(pin "1"
-			(uuid "b2adfc2d-3ada-40db-8f14-b56745a09d04")
+			(uuid "5047287f-0eab-4e6e-8f68-183718c26dd4")
 		)
 		(instances
 			(project "MainPowerDistributionSystem"
 				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "#PWR089")
+					(reference "#PWR056")
 					(unit 1)
 				)
 			)
@@ -8349,6 +7809,73 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+3.3V")
+		(at 151.13 303.53 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "ae5ea2ba-5374-47e3-90bf-d2063aba5c24")
+		(property "Reference" "#PWR065"
+			(at 154.94 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+GSE-2"
+			(at 147.32 303.5299 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 151.13 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 151.13 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 151.13 303.53 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "565c823e-7ce4-4b31-93bc-42d04e9b1ce8")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(reference "#PWR065")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Power_Management:TPS22810DRV")
 		(at 226.06 177.8 0)
 		(unit 1)
@@ -8499,6 +8026,73 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+3.3V")
+		(at 236.22 284.48 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c24212eb-3a76-423e-a616-680538fa4d29")
+		(property "Reference" "#PWR012"
+			(at 240.03 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+TE-1"
+			(at 232.41 284.4799 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 236.22 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 236.22 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 236.22 284.48 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "4c564c2e-a8e0-454f-85c5-e5ea3877072a")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(reference "#PWR012")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "power:GND")
 		(at 355.6 130.81 270)
 		(unit 1)
@@ -8625,76 +8219,6 @@
 			(project "MainPowerDistributionSystem"
 				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
 					(reference "#PWR031")
-					(unit 1)
-				)
-			)
-		)
-	)
-	(symbol
-		(lib_id "Device:D_Zener")
-		(at 217.17 334.01 270)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "c958f26c-2686-4647-bb5e-33bc02477f12")
-		(property "Reference" "D5"
-			(at 219.71 332.7399 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Value" "1N4727A"
-			(at 219.71 335.2799 90)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(justify left)
-			)
-		)
-		(property "Footprint" "Diode_THT:D_A-405_P7.62mm_Horizontal"
-			(at 217.17 334.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" "~"
-			(at 217.17 334.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Zener diode"
-			(at 217.17 334.01 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "952e679b-a765-47a3-9263-591697a3f340")
-		)
-		(pin "2"
-			(uuid "580122c4-48d7-4377-8e52-2afee2d08eda")
-		)
-		(instances
-			(project "MainPowerDistributionSystem"
-				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "D5")
 					(unit 1)
 				)
 			)
@@ -9442,6 +8966,73 @@
 	)
 	(symbol
 		(lib_id "power:+3.3V")
+		(at 236.22 321.31 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "e873578e-784d-4c88-8a92-73472400ee9e")
+		(property "Reference" "#PWR053"
+			(at 240.03 321.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+TE-3"
+			(at 232.41 321.3099 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 236.22 321.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 236.22 321.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
+			(at 236.22 321.31 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "98e1e5ba-ce6c-43f6-85ee-8fc5b48cca3b")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(reference "#PWR053")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:+3.3V")
 		(at 355.6 125.73 90)
 		(unit 1)
 		(exclude_from_sim no)
@@ -9973,72 +9564,6 @@
 			)
 		)
 	)
-	(symbol
-		(lib_id "power:+3.3V")
-		(at 217.17 297.18 0)
-		(unit 1)
-		(exclude_from_sim no)
-		(in_bom yes)
-		(on_board yes)
-		(dnp no)
-		(fields_autoplaced yes)
-		(uuid "fd950cf0-cd64-44bb-a95e-a93f03ff55c6")
-		(property "Reference" "#PWR012"
-			(at 217.17 300.99 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Value" "+TE-1"
-			(at 217.17 292.1 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-			)
-		)
-		(property "Footprint" ""
-			(at 217.17 297.18 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Datasheet" ""
-			(at 217.17 297.18 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(property "Description" "Power symbol creates a global label with name \"+3.3V\""
-			(at 217.17 297.18 0)
-			(effects
-				(font
-					(size 1.27 1.27)
-				)
-				(hide yes)
-			)
-		)
-		(pin "1"
-			(uuid "5818da78-7a06-47ba-8af7-cf0856dfdcce")
-		)
-		(instances
-			(project "MainPowerDistributionSystem"
-				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
-					(reference "#PWR012")
-					(unit 1)
-				)
-			)
-		)
-	)
 	(sheet
 		(at 198.12 77.47)
 		(size 58.42 12.7)
@@ -10113,6 +9638,384 @@
 		)
 	)
 	(sheet
+		(at 236.22 280.67)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "261c9762-dbc6-4b8c-91f7-76f368e53a64")
+		(property "Sheetname" "Timer Event Logic Conversion - TE-1"
+			(at 236.22 279.9584 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 236.22 288.8746 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 236.22 284.48 180)
+			(uuid "80374764-5646-45d5-b3f2-7c0e44f40e41")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 275.59 284.48 0)
+			(uuid "c7146915-a9d5-4eab-8135-9b53e0e767b9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "2")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 236.22 317.5)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "3f92f74e-3cca-4282-aab2-357fe1c1118f")
+		(property "Sheetname" "Timer Event Logic Conversion - TE-3"
+			(at 236.22 316.7884 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 236.22 325.7046 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 236.22 321.31 180)
+			(uuid "10932002-430d-45e5-be38-7aa0291be58c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 275.59 321.31 0)
+			(uuid "3e065a97-b895-4588-ba4d-79590025cd13")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "4")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 151.13 280.67)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "41b9944a-f63d-4ce0-843f-6c1f8b109fe2")
+		(property "Sheetname" "Timer Event Logic Conversion - GSE-1"
+			(at 151.13 279.9584 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 151.13 288.8746 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 151.13 284.48 180)
+			(uuid "487ea477-b46b-46a1-84a2-97ec64f87d5f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 190.5 284.48 0)
+			(uuid "43f83eca-6dc0-482e-ae40-666fd0b8e46a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "9")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 236.22 299.72)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "5794667a-7b17-4495-a615-6983a1fee026")
+		(property "Sheetname" "Timer Event Logic Conversion - TE-2"
+			(at 236.22 299.0084 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 236.22 307.9246 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 236.22 303.53 180)
+			(uuid "30b1e0a9-8338-4e10-8239-4cdfe1e88f77")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 275.59 303.53 0)
+			(uuid "ca634090-41e5-4904-8a97-ce7d9109c1cd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "3")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 151.13 299.72)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "5cd708ab-f243-4c3d-b9a6-6ef81c5046b4")
+		(property "Sheetname" "Timer Event Logic Conversion - GSE-2"
+			(at 151.13 299.0084 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 151.13 307.9246 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 151.13 303.53 180)
+			(uuid "57ff6840-1c2f-4e61-ad0a-ff0639ed29b4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 190.5 303.53 0)
+			(uuid "117e17cc-f139-40d1-aeb7-72f5b567c679")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "10")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 236.22 350.52)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8")
+		(property "Sheetname" "Timer Event Logic Conversion - TE-RB"
+			(at 236.22 349.8084 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 236.22 358.7246 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 236.22 354.33 180)
+			(uuid "14d254c5-f85a-4ccf-8f36-b94f987063aa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 275.59 354.33 0)
+			(uuid "558ec2ae-08e3-45ae-921a-a71adc14fb64")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "8")
+				)
+			)
+		)
+	)
+	(sheet
 		(at 198.12 99.06)
 		(size 58.42 12.7)
 		(exclude_from_sim no)
@@ -10181,6 +10084,69 @@
 			(project "MainPowerDistributionSystem"
 				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
 					(page "6")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 236.22 334.01)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "808cc913-2635-4e01-9a87-a42fd91b330a")
+		(property "Sheetname" "Timer Event Logic Conversion - TE-RA"
+			(at 236.22 333.2984 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 236.22 342.2146 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 236.22 337.82 180)
+			(uuid "4f784b2b-7f8f-4fc1-a9ae-f833243dec20")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 275.59 337.82 0)
+			(uuid "9575db67-f4bd-4663-8091-a511879c940e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2"
+					(page "7")
 				)
 			)
 		)

--- a/pcb/MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch
+++ b/pcb/MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch
@@ -1,0 +1,1294 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid "50f4cb93-fdc7-408b-bd97-3c3c28b9eb01")
+	(paper "A5")
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:D_Zener"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "D_Zener"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Zener diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "D_Zener_0_1"
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27) (xy -0.762 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "D_Zener_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(rectangle
+		(start 61.087 49.784)
+		(end 157.48 107.95)
+		(stroke
+			(width 0.8128)
+			(type solid)
+			(color 255 0 0 1)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 76c35ce9-055b-4656-9851-d5ad605c12be)
+	)
+	(text "Timer Event Logic Conversion (V0)."
+		(exclude_from_sim no)
+		(at 60.96 47.498 0)
+		(effects
+			(font
+				(size 3.2512 3.2512)
+				(thickness 0.6502)
+				(bold yes)
+				(italic yes)
+				(color 255 0 0 1)
+			)
+			(justify left bottom)
+		)
+		(uuid "2ffef1c3-ed5d-48d0-a94f-94f11164064d")
+	)
+	(text "Expected to draw 6.3mA - 9mA at 24V - 32V.\nPower disipated: 120mW - 241mW.\n\nResistor that allows for the highest current to\nthe zener without exceding its power rating.\n\nNote: Testing shows that zener can run at \nlower currents than specified on data sheet."
+		(exclude_from_sim no)
+		(at 110.49 79.248 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.1588)
+				(color 255 0 0 1)
+			)
+			(justify right)
+		)
+		(uuid "af590ad6-7031-4dea-8db8-85beace2586c")
+	)
+	(junction
+		(at 134.62 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb9985ef-520a-4664-a2c9-1e8230f6e067")
+	)
+	(junction
+		(at 114.3 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c034ef2d-3cc5-44e5-929b-de62c50d41f2")
+	)
+	(wire
+		(pts
+			(xy 114.3 85.09) (xy 134.62 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bdc3a5a-ce6b-4421-8458-9db5135b4c9f")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 114.3 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37b5a0a8-823c-403f-80e5-286be16b6805")
+	)
+	(wire
+		(pts
+			(xy 134.62 85.09) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "417b1ce9-8592-4acb-81c9-059358942d18")
+	)
+	(wire
+		(pts
+			(xy 134.62 96.52) (xy 134.62 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57035470-020e-44b0-9a03-0131b55a9172")
+	)
+	(wire
+		(pts
+			(xy 114.3 60.96) (xy 114.3 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "641e0af5-8992-4466-8a2e-216f23e89fd1")
+	)
+	(wire
+		(pts
+			(xy 114.3 81.28) (xy 114.3 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88d12e92-e31d-4461-a646-c5f3e7756f69")
+	)
+	(wire
+		(pts
+			(xy 114.3 96.52) (xy 114.3 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a196001a-0074-4af9-a2cc-5118ac0b838b")
+	)
+	(wire
+		(pts
+			(xy 134.62 85.09) (xy 146.05 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bae5193e-80e8-4faa-82d2-cfd951fd5a7d")
+	)
+	(wire
+		(pts
+			(xy 114.3 85.09) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4794bbf-e43f-4a1e-9b0f-d8386b69c983")
+	)
+	(hierarchical_label "OUTPUT"
+		(shape bidirectional)
+		(at 146.05 85.09 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "00539415-807e-42c3-8677-101d0dd06595")
+	)
+	(hierarchical_label "INPUT"
+		(shape bidirectional)
+		(at 114.3 55.88 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e8e1fa1c-53f8-4d39-b371-508acde2fda5")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 134.62 92.71 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0486685a-1100-4a71-9d86-d3952ae92015")
+		(property "Reference" "C25"
+			(at 138.43 91.4399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1u"
+			(at 138.43 93.9799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric_Pad1.33x1.80mm_HandSolder"
+			(at 135.5852 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 134.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 134.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11332d65-37a6-4408-b3ac-b97e756fc763")
+		)
+		(pin "2"
+			(uuid "6767cc82-2b4a-4d5b-9bfd-c88143967aee")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "C25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 114.3 100.33 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1ce204b0-632a-4b87-a634-19f2f6e12561")
+		(property "Reference" "#PWR014"
+			(at 114.3 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 114.3 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 114.3 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 114.3 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "74d383ad-01bd-446f-a879-f88e526c0f9b")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "#PWR014")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 114.3 64.77 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "47ca0805-3ef8-46f9-9226-a167b5d979c8")
+		(property "Reference" "D6"
+			(at 118.11 65.0874 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "WHITE"
+			(at 118.11 67.6274 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_1206_3216Metric_Pad1.42x1.75mm_HandSolder"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48875102-959f-4fdc-b051-c00752fca604")
+		)
+		(pin "2"
+			(uuid "33a88c47-3ace-408b-af30-28f5dc9fbf1a")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 114.3 77.47 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8404fa5e-050c-4960-a21c-653c303e3e11")
+		(property "Reference" "R13"
+			(at 116.84 76.1999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "3k"
+			(at 116.84 78.7399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_1206_3216Metric_Pad1.30x1.75mm_HandSolder"
+			(at 112.522 77.47 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 114.3 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "f21401c5-9f3d-44f9-bbe9-37a6fbdbb813")
+		)
+		(pin "1"
+			(uuid "3e8cf343-49be-49be-b630-25873df7eedd")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "R13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 134.62 100.33 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8a84e190-8619-43e2-9cbf-5aec959f50e3")
+		(property "Reference" "#PWR015"
+			(at 134.62 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 134.62 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 134.62 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 134.62 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba5c204b-4c7b-450d-82d6-7f8e62c21a97")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "#PWR015")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D_Zener")
+		(at 114.3 92.71 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c958f26c-2686-4647-bb5e-33bc02477f12")
+		(property "Reference" "D7"
+			(at 116.84 91.4399 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1N4727A"
+			(at 116.84 93.9799 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_A-405_P7.62mm_Horizontal"
+			(at 114.3 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Zener diode"
+			(at 114.3 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5f176445-5533-488f-b53d-b4cc71ceefab")
+		)
+		(pin "2"
+			(uuid "1e707924-265d-49af-a818-226d574e9463")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/pcb/VehiclePowerDistributionSystem.kicad_pro
+++ b/pcb/VehiclePowerDistributionSystem.kicad_pro
@@ -638,6 +638,10 @@
     [
       "885661a3-3ca5-4fb2-bf11-643a7d019368",
       "Stepper Motor Driver - Z"
+    ],
+    [
+      "54620fe3-2093-4758-a776-838cd07d45c6",
+      "Timer Event Logic Conversion - External Power"
     ]
   ],
   "text_variables": {}

--- a/pcb/VehiclePowerDistributionSystem.kicad_sch
+++ b/pcb/VehiclePowerDistributionSystem.kicad_sch
@@ -3978,6 +3978,28 @@
 			)
 		)
 	)
+	(global_label "EXTERNAL_DETECTED"
+		(shape bidirectional)
+		(at 353.06 64.77 0)
+		(fields_autoplaced yes)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "171c9322-f248-4418-ac5a-6ebe6dc382f5")
+		(property "Intersheetrefs" "${INTERSHEET_REFS}"
+			(at 376.5086 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+				(hide yes)
+			)
+		)
+	)
 	(global_label "MOTOR_DRIVER_A2_X"
 		(shape bidirectional)
 		(at 170.18 43.18 0)
@@ -9101,6 +9123,73 @@
 		)
 	)
 	(symbol
+		(lib_id "power:+BATT")
+		(at 313.69 64.77 90)
+		(mirror x)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(uuid "fd64afd0-21f2-4def-b152-b1861c532a01")
+		(property "Reference" "#PWR013"
+			(at 317.5 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "+EXTERNAL"
+			(at 309.88 64.7699 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 313.69 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 313.69 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"+BATT\""
+			(at 313.69 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ad004f8a-717a-464c-8a2a-9fed5615b052")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085"
+					(reference "#PWR013")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
 		(lib_id "Power_Management:TPS22810DRV")
 		(at 293.37 167.64 0)
 		(unit 1)
@@ -9322,6 +9411,69 @@
 			(project "VehiclePowerDistributionSystem"
 				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085"
 					(page "3")
+				)
+			)
+		)
+	)
+	(sheet
+		(at 313.69 60.96)
+		(size 39.37 7.62)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(stroke
+			(width 0.1524)
+			(type solid)
+			(color 132 0 0 1)
+		)
+		(fill
+			(color 255 255 194 1.0000)
+		)
+		(uuid "54620fe3-2093-4758-a776-838cd07d45c6")
+		(property "Sheetname" "Timer Event Logic Conversion - External Power"
+			(at 313.69 60.2484 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left bottom)
+			)
+		)
+		(property "Sheetfile" "VehiclePowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch"
+			(at 313.69 69.1646 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(pin "INPUT" bidirectional
+			(at 313.69 64.77 180)
+			(uuid "6e5a8a50-59e2-43f8-ac7d-c250e326691b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(pin "OUTPUT" bidirectional
+			(at 353.06 64.77 0)
+			(uuid "cd32f218-892d-4900-8f80-7409270241cf")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085"
+					(page "5")
 				)
 			)
 		)

--- a/pcb/VehiclePowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch
+++ b/pcb/VehiclePowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch
@@ -1,0 +1,1294 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid "50f4cb93-fdc7-408b-bd97-3c3c28b9eb01")
+	(paper "A5")
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:D_Zener"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "D_Zener"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Zener diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "D_Zener_0_1"
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27) (xy -0.762 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "D_Zener_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(rectangle
+		(start 61.087 49.784)
+		(end 157.48 107.95)
+		(stroke
+			(width 0.8128)
+			(type solid)
+			(color 255 0 0 1)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 76c35ce9-055b-4656-9851-d5ad605c12be)
+	)
+	(text "Timer Event Logic Conversion (V0)."
+		(exclude_from_sim no)
+		(at 60.96 47.498 0)
+		(effects
+			(font
+				(size 3.2512 3.2512)
+				(thickness 0.6502)
+				(bold yes)
+				(italic yes)
+				(color 255 0 0 1)
+			)
+			(justify left bottom)
+		)
+		(uuid "2ffef1c3-ed5d-48d0-a94f-94f11164064d")
+	)
+	(text "Expected to draw 6.3mA - 9mA at 24V - 32V.\nPower disipated: 120mW - 241mW.\n\nResistor that allows for the highest current to\nthe zener without exceding its power rating.\n\nNote: Testing shows that zener can run at \nlower currents than specified on data sheet."
+		(exclude_from_sim no)
+		(at 110.49 79.248 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.1588)
+				(color 255 0 0 1)
+			)
+			(justify right)
+		)
+		(uuid "af590ad6-7031-4dea-8db8-85beace2586c")
+	)
+	(junction
+		(at 134.62 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb9985ef-520a-4664-a2c9-1e8230f6e067")
+	)
+	(junction
+		(at 114.3 85.09)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c034ef2d-3cc5-44e5-929b-de62c50d41f2")
+	)
+	(wire
+		(pts
+			(xy 114.3 85.09) (xy 134.62 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bdc3a5a-ce6b-4421-8458-9db5135b4c9f")
+	)
+	(wire
+		(pts
+			(xy 114.3 68.58) (xy 114.3 73.66)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37b5a0a8-823c-403f-80e5-286be16b6805")
+	)
+	(wire
+		(pts
+			(xy 134.62 85.09) (xy 134.62 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "417b1ce9-8592-4acb-81c9-059358942d18")
+	)
+	(wire
+		(pts
+			(xy 134.62 96.52) (xy 134.62 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57035470-020e-44b0-9a03-0131b55a9172")
+	)
+	(wire
+		(pts
+			(xy 114.3 60.96) (xy 114.3 55.88)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "641e0af5-8992-4466-8a2e-216f23e89fd1")
+	)
+	(wire
+		(pts
+			(xy 114.3 81.28) (xy 114.3 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88d12e92-e31d-4461-a646-c5f3e7756f69")
+	)
+	(wire
+		(pts
+			(xy 114.3 96.52) (xy 114.3 100.33)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a196001a-0074-4af9-a2cc-5118ac0b838b")
+	)
+	(wire
+		(pts
+			(xy 134.62 85.09) (xy 146.05 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bae5193e-80e8-4faa-82d2-cfd951fd5a7d")
+	)
+	(wire
+		(pts
+			(xy 114.3 85.09) (xy 114.3 88.9)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4794bbf-e43f-4a1e-9b0f-d8386b69c983")
+	)
+	(hierarchical_label "OUTPUT"
+		(shape bidirectional)
+		(at 146.05 85.09 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "00539415-807e-42c3-8677-101d0dd06595")
+	)
+	(hierarchical_label "INPUT"
+		(shape bidirectional)
+		(at 114.3 55.88 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e8e1fa1c-53f8-4d39-b371-508acde2fda5")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 134.62 92.71 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0486685a-1100-4a71-9d86-d3952ae92015")
+		(property "Reference" "C25"
+			(at 138.43 91.4399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1u"
+			(at 138.43 93.9799 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric_Pad1.33x1.80mm_HandSolder"
+			(at 135.5852 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 134.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 134.62 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "11332d65-37a6-4408-b3ac-b97e756fc763")
+		)
+		(pin "2"
+			(uuid "6767cc82-2b4a-4d5b-9bfd-c88143967aee")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "C25")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 114.3 100.33 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1ce204b0-632a-4b87-a634-19f2f6e12561")
+		(property "Reference" "#PWR014"
+			(at 114.3 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 114.3 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 114.3 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 114.3 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 114.3 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "74d383ad-01bd-446f-a879-f88e526c0f9b")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "#PWR014")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 114.3 64.77 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "47ca0805-3ef8-46f9-9226-a167b5d979c8")
+		(property "Reference" "D6"
+			(at 118.11 65.0874 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "WHITE"
+			(at 118.11 67.6274 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_1206_3216Metric_Pad1.42x1.75mm_HandSolder"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 114.3 64.77 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "48875102-959f-4fdc-b051-c00752fca604")
+		)
+		(pin "2"
+			(uuid "33a88c47-3ace-408b-af30-28f5dc9fbf1a")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "D6")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 114.3 77.47 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8404fa5e-050c-4960-a21c-653c303e3e11")
+		(property "Reference" "R13"
+			(at 116.84 76.1999 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "3k"
+			(at 116.84 78.7399 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_1206_3216Metric_Pad1.30x1.75mm_HandSolder"
+			(at 112.522 77.47 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 114.3 77.47 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "f21401c5-9f3d-44f9-bbe9-37a6fbdbb813")
+		)
+		(pin "1"
+			(uuid "3e8cf343-49be-49be-b630-25873df7eedd")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "R13")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 134.62 100.33 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8a84e190-8619-43e2-9cbf-5aec959f50e3")
+		(property "Reference" "#PWR015"
+			(at 134.62 106.68 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 134.62 105.41 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 134.62 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 134.62 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 134.62 100.33 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "ba5c204b-4c7b-450d-82d6-7f8e62c21a97")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "#PWR015")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D_Zener")
+		(at 114.3 92.71 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c958f26c-2686-4647-bb5e-33bc02477f12")
+		(property "Reference" "D7"
+			(at 116.84 91.4399 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1N4727A"
+			(at 116.84 93.9799 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_A-405_P7.62mm_Horizontal"
+			(at 114.3 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 114.3 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Zener diode"
+			(at 114.3 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "5f176445-5533-488f-b53d-b4cc71ceefab")
+		)
+		(pin "2"
+			(uuid "1e707924-265d-49af-a818-226d574e9463")
+		)
+		(instances
+			(project "VehiclePowerDistributionSystem"
+				(path "/92a7a41c-8494-4e4b-ac2d-deb1f1cd8085/54620fe3-2093-4758-a776-838cd07d45c6"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+)

--- a/pcb/design.kicad_blocks/Timer_Event_Logic_Conversion.kicad_block/Timer_Event_Logic_Conversion.json
+++ b/pcb/design.kicad_blocks/Timer_Event_Logic_Conversion.kicad_block/Timer_Event_Logic_Conversion.json
@@ -1,0 +1,5 @@
+{
+"description": "",
+"keywords": "",
+"fields": {}
+}

--- a/pcb/design.kicad_blocks/Timer_Event_Logic_Conversion.kicad_block/Timer_Event_Logic_Conversion.kicad_sch
+++ b/pcb/design.kicad_blocks/Timer_Event_Logic_Conversion.kicad_block/Timer_Event_Logic_Conversion.kicad_sch
@@ -1,0 +1,1438 @@
+(kicad_sch
+	(version 20250114)
+	(generator "eeschema")
+	(generator_version "9.0")
+	(uuid "02200725-8b1b-4dda-b3ff-4261e63d5ccc")
+	(paper "A4")
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:D_Zener"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "D_Zener"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Zener diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "TO-???* *_Diode_* *SingleDiode* D_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "D_Zener_0_1"
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27) (xy -0.762 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 0) (xy -1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "D_Zener_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:LED"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 1.016)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "D"
+				(at 0 2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "LED"
+				(at 0 -2.54 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Light emitting diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Sim.Pins" "1=K 2=A"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "LED diode"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "LED* LED_SMD:* LED_THT:*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "LED_0_1"
+				(polyline
+					(pts
+						(xy -3.048 -0.762) (xy -4.572 -2.286) (xy -3.81 -2.286) (xy -4.572 -2.286) (xy -4.572 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 -0.762) (xy -3.302 -2.286) (xy -2.54 -2.286) (xy -3.302 -2.286) (xy -3.302 -1.524)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 0) (xy 1.27 0)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 -1.27) (xy -1.27 1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy 1.27 -1.27) (xy 1.27 1.27) (xy -1.27 0) (xy 1.27 -1.27)
+					)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "LED_1_1"
+				(pin passive line
+					(at -3.81 0 0)
+					(length 2.54)
+					(name "K"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 3.81 0 180)
+					(length 2.54)
+					(name "A"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:R"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "R"
+				(at 2.032 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "R"
+				(at 0 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at -1.778 0 90)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" "~"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "R res resistor"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_fp_filters" "R_*"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "R_0_1"
+				(rectangle
+					(start -1.016 -2.54)
+					(end 1.016 2.54)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "R_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 1.27)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power)
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(hide yes)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(name "~"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(rectangle
+		(start 43.307 45.974)
+		(end 139.7 104.14)
+		(stroke
+			(width 0.8128)
+			(type solid)
+			(color 255 0 0 1)
+		)
+		(fill
+			(type none)
+		)
+		(uuid 76c35ce9-055b-4656-9851-d5ad605c12be)
+	)
+	(text "Timer Event Logic Conversion (V0)."
+		(exclude_from_sim no)
+		(at 43.18 43.688 0)
+		(effects
+			(font
+				(size 3.2512 3.2512)
+				(thickness 0.6502)
+				(bold yes)
+				(italic yes)
+				(color 255 0 0 1)
+			)
+			(justify left bottom)
+		)
+		(uuid "2ffef1c3-ed5d-48d0-a94f-94f11164064d")
+	)
+	(text "Expected to draw 6.3mA - 9mA at 24V - 32V.\nPower disipated: 120mW - 241mW.\n\nResistor that allows for the highest current to\nthe zener without exceding its power rating.\n\nNote: Testing shows that zener can run at \nlower currents than specified on data sheet."
+		(exclude_from_sim no)
+		(at 92.71 75.438 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.1588)
+				(color 255 0 0 1)
+			)
+			(justify right)
+		)
+		(uuid "af590ad6-7031-4dea-8db8-85beace2586c")
+	)
+	(junction
+		(at 116.84 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "bb9985ef-520a-4664-a2c9-1e8230f6e067")
+	)
+	(junction
+		(at 96.52 81.28)
+		(diameter 0)
+		(color 0 0 0 0)
+		(uuid "c034ef2d-3cc5-44e5-929b-de62c50d41f2")
+	)
+	(wire
+		(pts
+			(xy 96.52 81.28) (xy 116.84 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "2bdc3a5a-ce6b-4421-8458-9db5135b4c9f")
+	)
+	(wire
+		(pts
+			(xy 96.52 64.77) (xy 96.52 69.85)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "37b5a0a8-823c-403f-80e5-286be16b6805")
+	)
+	(wire
+		(pts
+			(xy 116.84 81.28) (xy 116.84 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "417b1ce9-8592-4acb-81c9-059358942d18")
+	)
+	(wire
+		(pts
+			(xy 116.84 92.71) (xy 116.84 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "57035470-020e-44b0-9a03-0131b55a9172")
+	)
+	(wire
+		(pts
+			(xy 96.52 57.15) (xy 96.52 52.07)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "641e0af5-8992-4466-8a2e-216f23e89fd1")
+	)
+	(wire
+		(pts
+			(xy 96.52 77.47) (xy 96.52 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "88d12e92-e31d-4461-a646-c5f3e7756f69")
+	)
+	(wire
+		(pts
+			(xy 96.52 92.71) (xy 96.52 96.52)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "a196001a-0074-4af9-a2cc-5118ac0b838b")
+	)
+	(wire
+		(pts
+			(xy 116.84 81.28) (xy 128.27 81.28)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "bae5193e-80e8-4faa-82d2-cfd951fd5a7d")
+	)
+	(wire
+		(pts
+			(xy 96.52 81.28) (xy 96.52 85.09)
+		)
+		(stroke
+			(width 0)
+			(type default)
+		)
+		(uuid "f4794bbf-e43f-4a1e-9b0f-d8386b69c983")
+	)
+	(hierarchical_label "OUTPUT"
+		(shape bidirectional)
+		(at 128.27 81.28 0)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify left)
+		)
+		(uuid "00539415-807e-42c3-8677-101d0dd06595")
+	)
+	(hierarchical_label "INPUT"
+		(shape bidirectional)
+		(at 96.52 52.07 180)
+		(effects
+			(font
+				(size 1.27 1.27)
+			)
+			(justify right)
+		)
+		(uuid "e2db8ecf-ad60-4730-97da-d7078d28991f")
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 116.84 88.9 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "0486685a-1100-4a71-9d86-d3952ae92015")
+		(property "Reference" "C1"
+			(at 120.65 87.6299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1u"
+			(at 120.65 90.1699 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_1206_3216Metric_Pad1.33x1.80mm_HandSolder"
+			(at 117.8052 92.71 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 116.84 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Unpolarized capacitor"
+			(at 116.84 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f5b5c5d1-cfae-4f7a-84e8-8d5e3d0f100c")
+		)
+		(pin "2"
+			(uuid "ba1c47e9-aa1a-4e24-b3af-747d56f0eeb9")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/261c9762-dbc6-4b8c-91f7-76f368e53a64"
+					(reference "C1")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/3f92f74e-3cca-4282-aab2-357fe1c1118f"
+					(reference "C3")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/41b9944a-f63d-4ce0-843f-6c1f8b109fe2"
+					(reference "C6")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5794667a-7b17-4495-a615-6983a1fee026"
+					(reference "C2")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5cd708ab-f243-4c3d-b9a6-6ef81c5046b4"
+					(reference "C7")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8"
+					(reference "C5")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/808cc913-2635-4e01-9a87-a42fd91b330a"
+					(reference "C4")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 96.52 96.52 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "1ce204b0-632a-4b87-a634-19f2f6e12561")
+		(property "Reference" "#PWR088"
+			(at 96.52 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 96.52 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 96.52 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 96.52 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 96.52 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "f75594b3-9b34-46df-8165-c6c25a15a71e")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/261c9762-dbc6-4b8c-91f7-76f368e53a64"
+					(reference "#PWR088")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/3f92f74e-3cca-4282-aab2-357fe1c1118f"
+					(reference "#PWR054")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/41b9944a-f63d-4ce0-843f-6c1f8b109fe2"
+					(reference "#PWR063")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5794667a-7b17-4495-a615-6983a1fee026"
+					(reference "#PWR051")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5cd708ab-f243-4c3d-b9a6-6ef81c5046b4"
+					(reference "#PWR066")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8"
+					(reference "#PWR060")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/808cc913-2635-4e01-9a87-a42fd91b330a"
+					(reference "#PWR057")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:LED")
+		(at 96.52 60.96 90)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "47ca0805-3ef8-46f9-9226-a167b5d979c8")
+		(property "Reference" "D4"
+			(at 100.33 61.2774 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Value" "RED"
+			(at 100.33 63.8174 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify right)
+			)
+		)
+		(property "Footprint" "LED_SMD:LED_1206_3216Metric_Pad1.42x1.75mm_HandSolder"
+			(at 96.52 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 96.52 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Light emitting diode"
+			(at 96.52 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Sim.Pins" "1=K 2=A"
+			(at 96.52 60.96 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "bc58b082-634b-4dba-b04e-1f5135749efa")
+		)
+		(pin "2"
+			(uuid "e433d065-f8d5-4490-baf0-7143d1811420")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/261c9762-dbc6-4b8c-91f7-76f368e53a64"
+					(reference "D4")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/3f92f74e-3cca-4282-aab2-357fe1c1118f"
+					(reference "D3")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/41b9944a-f63d-4ce0-843f-6c1f8b109fe2"
+					(reference "D11")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5794667a-7b17-4495-a615-6983a1fee026"
+					(reference "D1")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5cd708ab-f243-4c3d-b9a6-6ef81c5046b4"
+					(reference "D13")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8"
+					(reference "D9")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/808cc913-2635-4e01-9a87-a42fd91b330a"
+					(reference "D7")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:R")
+		(at 96.52 73.66 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8404fa5e-050c-4960-a21c-653c303e3e11")
+		(property "Reference" "R2"
+			(at 99.06 72.3899 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "3k"
+			(at 99.06 74.9299 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Resistor_SMD:R_1206_3216Metric_Pad1.30x1.75mm_HandSolder"
+			(at 94.742 73.66 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 96.52 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Resistor"
+			(at 96.52 73.66 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "2"
+			(uuid "20561cd9-938b-4c94-9739-260a504acb38")
+		)
+		(pin "1"
+			(uuid "635454cc-f672-4980-9a70-e56a88b29b40")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/261c9762-dbc6-4b8c-91f7-76f368e53a64"
+					(reference "R2")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/3f92f74e-3cca-4282-aab2-357fe1c1118f"
+					(reference "R4")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/41b9944a-f63d-4ce0-843f-6c1f8b109fe2"
+					(reference "R7")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5794667a-7b17-4495-a615-6983a1fee026"
+					(reference "R3")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5cd708ab-f243-4c3d-b9a6-6ef81c5046b4"
+					(reference "R8")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8"
+					(reference "R6")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/808cc913-2635-4e01-9a87-a42fd91b330a"
+					(reference "R5")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 116.84 96.52 0)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "8a84e190-8619-43e2-9cbf-5aec959f50e3")
+		(property "Reference" "#PWR089"
+			(at 116.84 102.87 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Value" "GND"
+			(at 116.84 101.6 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Footprint" ""
+			(at 116.84 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" ""
+			(at 116.84 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+			(at 116.84 96.52 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "d30e0958-066b-48bf-9417-d4f6f21133f2")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/261c9762-dbc6-4b8c-91f7-76f368e53a64"
+					(reference "#PWR089")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/3f92f74e-3cca-4282-aab2-357fe1c1118f"
+					(reference "#PWR055")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/41b9944a-f63d-4ce0-843f-6c1f8b109fe2"
+					(reference "#PWR064")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5794667a-7b17-4495-a615-6983a1fee026"
+					(reference "#PWR052")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5cd708ab-f243-4c3d-b9a6-6ef81c5046b4"
+					(reference "#PWR067")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8"
+					(reference "#PWR061")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/808cc913-2635-4e01-9a87-a42fd91b330a"
+					(reference "#PWR058")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:D_Zener")
+		(at 96.52 88.9 270)
+		(unit 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "c958f26c-2686-4647-bb5e-33bc02477f12")
+		(property "Reference" "D5"
+			(at 99.06 87.6299 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "1N4727A"
+			(at 99.06 90.1699 90)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Diode_THT:D_A-405_P7.62mm_Horizontal"
+			(at 96.52 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Datasheet" "~"
+			(at 96.52 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(property "Description" "Zener diode"
+			(at 96.52 88.9 0)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(hide yes)
+			)
+		)
+		(pin "1"
+			(uuid "66b404a5-a50e-4f0b-9c15-0f3b094cb915")
+		)
+		(pin "2"
+			(uuid "ffd90b90-5572-4d53-81dd-4cd5286cfb6e")
+		)
+		(instances
+			(project "MainPowerDistributionSystem"
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/261c9762-dbc6-4b8c-91f7-76f368e53a64"
+					(reference "D5")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/3f92f74e-3cca-4282-aab2-357fe1c1118f"
+					(reference "D6")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/41b9944a-f63d-4ce0-843f-6c1f8b109fe2"
+					(reference "D12")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5794667a-7b17-4495-a615-6983a1fee026"
+					(reference "D2")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/5cd708ab-f243-4c3d-b9a6-6ef81c5046b4"
+					(reference "D14")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/7bfeb19b-cfbf-4688-9fe2-f6b9e19ab4b8"
+					(reference "D10")
+					(unit 1)
+				)
+				(path "/f4672588-55b2-48e9-8f23-132a69134eb2/808cc913-2635-4e01-9a87-a42fd91b330a"
+					(reference "D8")
+					(unit 1)
+				)
+			)
+		)
+	)
+)


### PR DESCRIPTION
@mwlacy, a lot has changed when it comes to the PCB stuff since I first assigned you that task of making a schematic for the timer event conversion, but to not let your work go to waste, here's what I'm doing to reuse the circuit.

(Don't worry too much about following along, this is so I can document the advance KiCad stuff for future reference.)

---

First, I copy-pasted the schematic you made into the most up-to-date version of the KiCad project (which is `MainPowerDistributionSystem.kicad_sch` on the `PCB_Development` branch).

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/43d83758-8769-4e75-b9bf-84a21f1a4980" width="600px"></kbd></p>&nbsp;

---

To make your circuit reusable, I'm going to make a hierarchical sheet.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/b704ddee-27db-4c25-a9da-7b77f6de09ce" width="600px"></kbd></p>&nbsp;

---

I'm giving the subsheet the name of `Timer Event Logic Conversion - TE-1` in anticipation of `Timer Event Logic Conversion - TE-2`, `Timer Event Logic Conversion - TE-3`, and so on. The sheet file name is going to be `MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch` where `MainPowerDistributionSystem` is the name of the current KiCad project that the sheet is in; you could name it anything, but there's a specific reason for this naming scheme that I won't get into now because it's a lot.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/583dbf04-39da-4fb3-b0b7-4a9cf5fd64e7" width="600px"></kbd></p>&nbsp;

---

Also, KiCad by default for some reason doesn't give a border and fill color, so if you don't want the subsheet to look weird, you should use `#FFFFC2FF` for the fill and `#840000FF` for the border so it looks like all the other symbols.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/d09c02fb-ace2-48ca-b025-19a78d1cf954" width="600px"></kbd></p>&nbsp;

---

Next, I cut-and-paste the TE conversion circuit into the subsheet.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/d9cb674d-266d-4e96-8bb2-199b77583343" width="600px"></kbd></p>&nbsp;

---

Now I place some hierarchical labels in the hierarchical sheet.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/81d260e7-bb87-4401-88e7-840fdeb2b850" width="600px"></kbd></p>&nbsp;

---

Hierarchical labels are how input and outputs to the hierarchical sheet are done. In the case of the timer-event logic conversion circuit, the input to the circuit can be different (e.g. `TE-1`, `TE-2`, `GSE-1`, etc.) so we'll generically call it `INPUT`.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/1c9fb759-de83-45f0-846b-1492a62136e8" width="600px"></kbd></p>&nbsp;

I also set the shape of the label to be `Bidirectional`. This doesn't do anything important; I just like the shape of it.

---

I make and put the hierarchical labels at the input and output accordingly.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/a049f76d-3a79-4240-9f52-6c35949c7405" width="600px"></kbd></p>&nbsp;

---

We then go back up to the root schematic sheet and begin placing sheet pins.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/0fc1dfbf-a02e-484c-a7c2-1543f0f3d7e6" width="600px"></kbd></p>&nbsp;

---

By clicking on that button and then clicking on the subsheet box, I can place the `INPUT` and `OUTPUT` labels accordingly.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/d9b79752-bef3-48e6-b3a7-a34497859c55" width="600px"></kbd></p>&nbsp;

---

With that, I can hook up things to those pins like any other schematic symbol. In this case, we have `+TE-1` power symbol at the `INPUT` and the global label `LOGIC_TIMER_EVENT_1` at the `OUTPUT`.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/1ca9c409-c896-4bef-b39a-1facec206c22" width="600px"></kbd></p>&nbsp;

---

Once we got that, we can straight-up just copy-paste this part for each rocket power line there is!

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/418e1965-b9c1-4797-866f-3ba5e5774984" width="600px"></kbd></p>&nbsp;

---

Now, hierarchical sheets are useful because if you change one subsheet, like changing the color of the LED from `RED` to `WHITE`, then it also happens to all of the other subsheets!

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/7e41a709-1cb1-4a1d-a815-4527f55b9bd6" width="600px"></kbd></p>&nbsp;

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/69b22946-f82e-4fa6-8d39-b1f9f85e674a" width="600px"></kbd></p>&nbsp;

---

Now this is just on the `MainPowerDistributionSystem.kicad_sch` schematic; the `VehiclePowerDistributionSystem.kicad_sch` also needs to convert +28V to +3.3V logic (this is the external power and it's how the vehicle knows whether or not it's currently docked).

I go to `VehiclePowerDistributionSystem.kicad_sch` and copy-paste the hierarchical sheet stuff from earlier. However, instead of `MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch`, I change it to `VehiclePowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch` which will result in KiCad making a new subsheet file for that.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/064bdb5a-7743-4224-bc1e-2a81a39da532" width="600px"></kbd></p>&nbsp;

---

I then adjust the input and outputs accordingly.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/5cf80c34-9dbe-4d47-8ef5-ee5b176604ce" width="600px"></kbd></p>&nbsp;

---

The reason why a new subsheet file had to be made (now there's `MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch` and also `VehiclePowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch`) is because KiCad handles hierarchical sheets in such a broken way that you can't reuse the same subsheet in different projects.

So to make the timer event logic conversion circuit is fully reusable, I'm going to have to make something call a *design block*, which is just a way we can copy-paste schematic symbols.

First, I like to draw a thick red box around the schematic I'd like to turn into a design block and give it a title.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/10eae181-a549-43d3-8d40-24cb2601f629" width="600px"></kbd></p>&nbsp;

The most important thing in the title is the *version number*. Since we're creating a new design block, it's going to be `(V0)` as in "version zero". I'll explain this more later.

---

I then select the entirety of the schematic that I want to turn into a design block and in the Design Block panel, I right-click to `Save Selection as Design Block`.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/a22c0368-7d9e-4bfd-a81d-554fdb2e538c" width="600px"></kbd></p>&nbsp;

> [!TIP]
> By default, KiCad doesn't show the Design Block panel, but here's how you summon it:
> <p align="center"><kbd><img src="https://github.com/user-attachments/assets/c5626703-f72a-49c6-8814-2784b17d96b4" width="600px"></kbd></p>&nbsp;
> If the Design Block panel is completely empty, make sure you're in the right KiCad project.

---

I give the design block the name of `Timer_Event_Logic_Conversion`.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/349db865-3702-4a1a-8b00-f88e774020a1" width="600px"></kbd></p>&nbsp;

---

As said, with design blocks, it can be used to essentially copy-paste schematics of circuits.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/552c915f-90a6-4b6f-8f70-6b5f7f5fb7d6" width="600px"></kbd></p>&nbsp;

---

The reason why there's a version tag in the design block's title is because if any modifications were made at all to the enclosed circuit, the version should be bumped with a description. For instance, if the LED color was changed from red to white, we'd go from `(V0)` to `(V1 : Using white LED)`. The design block for `Timer_Event_Logic_Conversion` would be overwritten with the new version of the circuit.

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/e3d682c4-537f-4743-80bd-34e2317a19e3" width="600px"></kbd></p>&nbsp;

As another example, if the resistor value was changed, we might go from `(V1 : Using white LED)` to `(V2 : Updated resistor value)` for instance.

This is just a poor-man's way of doing version control, but it's especially useful for determining whether or not a particular reused circuit is up-to-date.

---

The reason why I made a design block for the circuit is because if the circuit in `VehiclePowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch` was modified, then all the subsheets deriving from that will be updated, but not `MainPowerDistributionSystem_Timer_Event_Logic_Conversion.kicad_sch`. So to keep the two subsheet files consistent, design blocks are used to ensure the circuits in the subsheets are the same version.

---

Alright, that was a lot of information, if you read any of it.

Trust me, I wish it was a whole lot easier...