### PR TITLE
Added `FSPI_PATCH` switch to toggle the FSPI usage for the ESP32s.

### DIFF
--- a/electrical/system.h
+++ b/electrical/system.h
@@ -919,11 +919,12 @@ ESP32_calculate_crc(u8* data, i32 length)
 
 #if COMPILING_ESP32
 
+    #define FSPI_PATCH false // TODO Look into why it works sometimes...
+
     #include <WiFi.h>
     #include <esp_wifi.h>
     #include <esp_now.h>
     #include <RadioLib.h>
-    #include <SPI.h>
 
 
 
@@ -955,24 +956,40 @@ ESP32_calculate_crc(u8* data, i32 length)
 
     }
 
-    //Initializes SPI class and calls the fspi bus peripheral
-    SPIClass fspi(FSPI);
-
-    //Initializes LoRa radio signals with pin mapping for NSS, DIO1, RESET, BUSY, and fspi bus
-    //ex. NSS assigned to GPIO41 (NSS must be same as fspi pin mapping) 
-    static SX1262 packet_lora_radio = new Module(41, 39, 42, 40, fspi);
 
 
+    #if FSPI_PATCH
 
-    // TODO Look more into the specs.
+        #include <SPI.h>
+
+        // Initializes SPI class and calls the fspi bus peripheral
+        SPIClass fspi(FSPI);
+
+        // Initializes LoRa radio signals with pin mapping for NSS, DIO1, RESET, BUSY, and fspi bus
+        // ex. NSS assigned to GPIO41 (NSS must be same as fspi pin mapping)
+        static SX1262 packet_lora_radio = new Module(41, 39, 42, 40, fspi);
+
+    #else
+
+        static SX1262 packet_lora_radio = new Module(41, 39, 42, 40);
+
+    #endif
+
+
+
     // TODO Make robust.
     extern void
     common_init_lora()
     {
-        //Creates an instance of the SPI for the fspi hardware controller
-        //Assigns the SX1262 signals (SCK, MISO, MOSI, and NSS) to specific GPIO pins of the ESP32S3
-        //ex. SCK is assigned to GPIO36
-        fspi.begin(36, 37, 35, 41);
+
+        #if FSPI_PATCH
+
+            // Creates an instance of the SPI for the fspi hardware controller
+            // Assigns the SX1262 signals (SCK, MISO, MOSI, and NSS) to specific GPIO pins of the ESP32S3
+            // ex. SCK is assigned to GPIO36
+            fspi.begin(36, 37, 35, 41);
+
+        #endif
 
         if (packet_lora_radio.begin() != RADIOLIB_ERR_NONE)
         {
@@ -981,40 +998,40 @@ ESP32_calculate_crc(u8* data, i32 length)
             return;
         }
 
-        //915 MHz Center Frequency (common frequency used in North America)
-        //Should range from 902-928 for most cases
-        //Find out if different frequencies affect range
+        // 915 MHz Center Frequency (common frequency used in North America)
+        // Should range from 902-928 for most cases
+        // Find out if different frequencies affect range
         packet_lora_radio.setFrequency(915.0);
 
-        //7.8kHz Bandwidth (Narrow)
-        //Ranges from 7.8kHz to 500kHz
-        //Slower data rate but longer range compare to a larger bandwidth
+        // 7.8kHz Bandwidth (Narrow)
+        // Ranges from 7.8kHz to 500kHz
+        // Slower data rate but longer range compare to a larger bandwidth
         packet_lora_radio.setBandwidth(7.8);
 
-        //6 (less than 22 kbps) Usually ranges from 7-12 (22-250 kbps)
-        //May need to be reconfigured depending on range/speed desired
-        //What's essential to know: A higher spreading factor means slower data rate but further transmission and vice versa
+        // 6 (less than 22 kbps) Usually ranges from 7-12 (22-250 kbps)
+        // May need to be reconfigured depending on range/speed desired
+        // What's essential to know: A higher spreading factor means slower data rate but further transmission and vice versa
         packet_lora_radio.setSpreadingFactor(6);
 
-        //(4/5) Coding Rate 
-        //Proportion of foward error correction bits added to payload
-        //A higher coding rate makes transmission less noisy but reduces effective data rate
+        // (4/5) Coding Rate
+        // Proportion of foward error correction bits added to payload
+        // A higher coding rate makes transmission less noisy but reduces effective data rate
         packet_lora_radio.setCodingRate(5);
 
-        //22 dBm, for the SX1262 this is the specified max TX output power
-        //Max output power gives the most range and its recommended to run the LoRa at this level
-        //Dont go above this or may risk damaging component
-        //test to see minimum power, likely -9dBm
+        // 22 dBm, for the SX1262 this is the specified max TX output power
+        // Max output power gives the most range and its recommended to run the LoRa at this level
+        // Dont go above this or may risk damaging component
+        // test to see minimum power, likely -9dBm
         packet_lora_radio.setOutputPower(22);
 
-        //8 Symbol Preamble Length (Standard for LoRa)
-        //Synchronizes reciever with transmitter
+        // 8 Symbol Preamble Length (Standard for LoRa)
+        // Synchronizes reciever with transmitter
         packet_lora_radio.setPreambleLength(8);
 
-        //0x34 LoRaWAN Public Network sync word
+        // 0x34 LoRaWAN Public Network sync word
         packet_lora_radio.setSyncWord(0x34);
 
-        //Adds Error Detection to packets
+        // Adds Error Detection to packets
         packet_lora_radio.setCRC(true);
 
 


### PR DESCRIPTION
The initialization of the LoRa modules with RadioLib is inconsistent; without using FSPI, the LoRa initialization works when the ESP32s are programmed by my PC, my laptop, and @mwlacy's computer, but not on @danielb19's computer. When FSPI is enabled, the LoRa module no longer works with my PC nor Maggie's computer, but still works on my laptop and Daniel's computer.

Software's fun.

I suspect this could be due to differences in the ESP32s or perhaps in the software versioning. I'll have to look this more later on, but for now, the usage of FSPI can be toggled using `FSPI_PATCH`.